### PR TITLE
Ignore deprecated flake8 rule.

### DIFF
--- a/{{ cookiecutter.repo_name }}/.flake8
+++ b/{{ cookiecutter.repo_name }}/.flake8
@@ -1,3 +1,3 @@
 [flake8]
 max-line-length = 120
-ignore = F841,E722,W605,E265,E501
+ignore = F841,E722,W605,E265,E501,W503


### PR DESCRIPTION
This rule is deprecated and should be ignored by default: https://www.flake8rules.com/rules/W503.html